### PR TITLE
Create rust-toolchain.toml

### DIFF
--- a/async_rust/chapter_5/why_use_coroutines/rust-toolchain.toml
+++ b/async_rust/chapter_5/why_use_coroutines/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
File needed to use the nightly rust toolchain without changing the default configuration